### PR TITLE
fix(spinner):Fixed spinner animation interruption bug. 

### DIFF
--- a/src/RazorConsole.Core/Renderables/AnimatedSpinnerRenderable.cs
+++ b/src/RazorConsole.Core/Renderables/AnimatedSpinnerRenderable.cs
@@ -53,7 +53,6 @@ internal sealed class AnimatedSpinnerRenderable : IRenderable, IAnimatedConsoleR
 
         // Use global time so new instances continue the animation instead of restarting.
         var intervalTicks = _interval.Ticks;
-        if (intervalTicks <= 0) intervalTicks = TimeSpan.FromMilliseconds(100).Ticks;
 
         // Use DateTime.UtcNow.Ticks as continuous clock.
         var tick = DateTime.UtcNow.Ticks / intervalTicks;


### PR DESCRIPTION
# Problem

When the UI is interacted with (e.g. button click or navigation menu toggle), spinner instances get recreated and their animation restarts from the beginning. This produces a visible jump in the spinner every time the DOM is re-rendered.

# Root cause

Each AnimatedSpinnerRenderable started its own Stopwatch in the constructor, so a newly created instance always displayed frame 0. Re-creating the renderable on every interaction therefore resets the spinner.

# Solution

Compute the current frame from a global clock instead of using a per-instance Stopwatch. The spinner frame index is now derived from DateTime.UtcNow (scaled by spinner interval), so new instances continue the animation position instead of starting over.