### PR TITLE
Remove 'Focus Management' from Docs

### DIFF
--- a/website/src/pages/Docs.tsx
+++ b/website/src/pages/Docs.tsx
@@ -6,7 +6,6 @@ import builtInComponentsDoc from "@/docs/built-in-components.md?raw";
 import hotReloadDoc from "@/docs/hot-reload.md?raw";
 import customTranslatorsDoc from "@/docs/custom-translators.md?raw";
 import keyboardEventsDoc from "@/docs/keyboard-events.md?raw";
-import focusManagementDoc from "@/docs/focus-management.md?raw";
 import componentGalleryDoc from "@/docs/component-gallery.md?raw";
 import { MarkdownRenderer } from "@/components/Markdown";
 


### PR DESCRIPTION
Removed 'Focus Management' section from documentation.