### PR TITLE
Add CliInfo page to gallery

### DIFF
--- a/src/RazorConsole.Gallery/Components/App.razor
+++ b/src/RazorConsole.Gallery/Components/App.razor
@@ -83,6 +83,7 @@
         ("scrollable", "Scrollable"),
         ("textbutton", "Text Button"),
         ("textinput", "Text Input"),
+        ("cli-info", "CLI Info"),
     };
 
     private readonly Padding _navigationPadding = new Padding(1, 1, 1, 1);

--- a/src/RazorConsole.Gallery/Components/CliInfo.razor
+++ b/src/RazorConsole.Gallery/Components/CliInfo.razor
@@ -1,0 +1,144 @@
+@page "/cli-info"
+@using System.Runtime.InteropServices
+@using Spectre.Console
+@using System.Globalization
+<Rows>
+
+    <Markup Content="Information about current CLI (and some system info)" Foreground="@Color.Grey70" />
+    <SpectreTable Title="General" ShowHeaders="false" Expand="true">
+        @foreach (var item in _generalInfo)
+        {
+            <SpectreTR>
+                <SpectreTD>
+                    <Markup Content="@($"{item.Key}:")" />
+                </SpectreTD>
+                <SpectreTD>
+                    <Markup Content="@item.Value" Foreground="@Color.Green3" />
+                </SpectreTD>
+            </SpectreTR>
+        }
+    </SpectreTable>
+    <SpectreTable ShowHeaders="false" Expand="true">
+        <SpectreTR>
+            <SpectreTD>
+                <Markup Content="Foreground color:" />
+            </SpectreTD>
+            <SpectreTD>
+                <Markup Content="@Console.ForegroundColor.ToString()" />
+            </SpectreTD>
+        </SpectreTR>
+        <SpectreTR>
+            <SpectreTD>
+                <Markup Content="Background color:" />
+            </SpectreTD>
+            <SpectreTD>
+                <Markup Content="@Console.BackgroundColor.ToString()" />
+            </SpectreTD>
+        </SpectreTR>
+        <SpectreTR>
+            <SpectreTD>
+                <Markup Content="CLI size:" />
+            </SpectreTD>
+            <SpectreTD>
+                <Markup Content="@($"{_windowSizeX} X {_windowSizeY}")" />
+            </SpectreTD>
+        </SpectreTR>
+        <SpectreTR>
+            <SpectreTD>
+                <Markup Content="CLI buffer size:" />
+            </SpectreTD>
+            <SpectreTD>
+                <Markup Content="@($"{_bufferSizeX} x {_bufferSizeY}")" />
+            </SpectreTD>
+        </SpectreTR>
+    </SpectreTable>
+    <Panel>
+
+        <Rows>
+            <Columns>
+                <Columns>
+                    <Markup Content="Input redirected:" />
+                    @{
+                        var isEnabled = Console.IsInputRedirected;
+                    }
+                    <Markup Content="@(isEnabled ? "✔️" : "✖")" Foreground="@(isEnabled? Color.Red: Color.Green)" />
+                </Columns>
+                <Columns>
+                    <Markup Content="Output redirected:" />
+                    @{
+                        var isEnabled = Console.IsOutputRedirected;
+                    }
+                    <Markup Content="@(isEnabled ? "✔️" : "✖")" Foreground="@(isEnabled? Color.Red: Color.Green)" />
+                </Columns>
+                <Columns>
+                    <Markup Content="Error redirected:" />
+                    @{
+                        var isEnabled = Console.IsErrorRedirected;
+                    }
+                    <Markup Content="@(isEnabled ? "✔️" : "✖")" Foreground="@(isEnabled? Color.Red: Color.Green)" />
+                </Columns>
+            </Columns>
+        </Rows>
+    </Panel>
+
+    <SpectreTable Title="CLI Features" ShowHeaders="false" Expand="true">
+        @foreach (var item in _cliFeatures)
+        {
+            <SpectreTR>
+                <SpectreTD>
+                    <Markup Content="@($"{item.Key}:")" />
+                </SpectreTD>
+                <SpectreTD>
+                    <Markup Content="@item.Value.ToString()" />
+                </SpectreTD>
+            </SpectreTR>
+        }
+    </SpectreTable>
+</Rows>
+
+@code {
+    private sealed record RowData<TValue>(string Key, TValue Value);
+
+    private IReadOnlyList<RowData<string>> _generalInfo = [];
+    private IReadOnlyList<RowData<bool>> _cliFeatures = [];
+
+    private string _windowSizeX = "N/A";
+    private string _windowSizeY = "N/A";
+    private string _bufferSizeX = "N/A";
+    private string _bufferSizeY = "N/A";
+
+    protected override void OnInitialized()
+    {
+        _generalInfo = new List<RowData<string>>()
+        {
+            new ("OS architecture", RuntimeInformation.ProcessArchitecture.ToString()),
+            new ("OS description", RuntimeInformation.OSDescription),
+            new ("Framework", RuntimeInformation.FrameworkDescription),
+            new ("RID", RuntimeInformation.RuntimeIdentifier),
+            new ("UI culture", CultureInfo.CurrentUICulture.Name),
+            new ("Current culture", CultureInfo.CurrentCulture.Name),
+        };
+
+        var cliCapabilities = AnsiConsole.Console.Profile.Capabilities;
+        _cliFeatures = new List<RowData<bool>>()
+        {
+            new ("Alternate buffer", cliCapabilities.AlternateBuffer),
+            new ("Ansi", cliCapabilities.Ansi),
+            new ("Interactive", cliCapabilities.Interactive),
+            new ("Legacy", cliCapabilities.Legacy),
+            new ("Links", cliCapabilities.Links),
+            new ("Unicode", cliCapabilities.Unicode),
+        };
+
+        try
+        {
+            _windowSizeX = Console.WindowWidth.ToString();
+            _windowSizeY = Console.WindowHeight.ToString();
+            _bufferSizeX = Console.BufferWidth.ToString();
+            _bufferSizeY = Console.BufferHeight.ToString();
+        }
+        catch (Exception) { }
+
+    }
+
+}


### PR DESCRIPTION
Partially solves #84 (bc im not sure of what type of information is required)

Now when you just run gallery it starts app (as before).
Now when you run gallery with `debug-cli` command it outputs debug info (i.e. `razorconsole-gallery debug-cli`).

Feel free to requrest exact debug information (with ways to gather it).

`debug-cli` outputs json (bc i thought it would be much easier to parse / navigate).
For example on my system it outputs
```json
{
    "os": {
        "architecture": "X64",
        "description": "Microsoft Windows 10.0.26200",
        "framework": ".NET 8.0.22",
        "rid": "win-x64"
    },
    "culture": {
        "ui": "ru-RU",
        "current": "ru-RU"
    },
    "console": {
        "encoding": {
            "input": "Codepage - 866",
            "output": "Codepage - 866"
        },
        "redirection": {
            "inputRedirected": "False",
            "outputRedirected": "False",
            "errorRedirected": "False"
        },
        "size": {
            "window": {
                "x": "120",
                "y": "30"
            },
            "buffer": {
                "x": "120",
                "y": "30",
            }
        },
        "color": {
            "foreground": "Gray",
            "background": "Black"
        }
    }
}
```

I also added `launchSettting.json` to easilly test that command. Just set `commandLineArgs` to `debug-cli` and it will always lunch debug command when run

