### PR TITLE
fix(core.components):Fix border and title color hex bug in Panel component.

### DIFF
--- a/src/RazorConsole.Core/Components/Panel.razor
+++ b/src/RazorConsole.Core/Components/Panel.razor
@@ -58,9 +58,9 @@
 
     private string? TitleAttribute => string.IsNullOrWhiteSpace(Title) ? null : Title;
 
-    private string? HeaderColorAttribute => TitleColor?.ToString();
+    private string? HeaderColorAttribute => TitleColor?.ToMarkup();
 
-    private string? BorderColorAttribute => BorderColor?.ToString();
+    private string? BorderColorAttribute => BorderColor?.ToMarkup();
 
     private string? BorderAttribute
     {


### PR DESCRIPTION
# Overview

When I tried to change panel color to some Hex value (method `Color.FromHex`) then I faced with issue - color was not applied or render freeze because of uncaught exception.

# Problem cause

Problem was in incorrect style conversion:
```cs
private string? BorderColorAttribute => BorderColor?.ToString();
```
`ToString` in hex case returns non-markup translation, so style parser falls:

<img width="1358" height="499" alt="exception screenshot" src="https://github.com/user-attachments/assets/ce40eac5-18f3-4ca7-86e2-caafe33957d7" />

# Solution:
Just changing `ToString` method to `ToMarkup` makes the trick.
