### PR TITLE
refactor(components):Remove unnecessary nullable string in select ValueChange callback.

### DIFF
--- a/design-doc/builtin-components.md
+++ b/design-doc/builtin-components.md
@@ -151,7 +151,7 @@ Interactive dropdown for choosing a value. Integrates with the focus and keyboar
 |-----------|------|---------|-------------|
 | `Options` | `string[]` | `Array.Empty<string>()` | Available options. |
 | `Value` | `string?` | `null` | Current selection. |
-| `ValueChanged` | `EventCallback<string?>` | — | Raised on selection change. |
+| `ValueChanged` | `EventCallback<string>` | — | Raised on selection change. |
 | `OnSelected` | `EventCallback<string?>` | — | Fired after a user confirms an option. |
 | `OnClear` | `EventCallback` | — | Fired when selection is cleared. |
 | `Placeholder` | `string` | `"Select an option"` | Placeholder when no selection is set. |

--- a/src/RazorConsole.Core/Components/Select.razor
+++ b/src/RazorConsole.Core/Components/Select.razor
@@ -87,7 +87,7 @@
     /// Event raised when the committed value changes.
     /// </summary>
     [Parameter]
-    public EventCallback<string?> ValueChanged { get; set; }
+    public EventCallback<string> ValueChanged { get; set; }
 
     /// <summary>
     /// Currently highlighted option during keyboard navigation (may differ from committed Value).
@@ -130,7 +130,7 @@
     // Focus-adjusted styling methods
     private Color GetFocusAdjustedColor(Color color) => IsFocused ? color : Color.Grey50;
 
-    private Decoration GetFocusAdjustedDecoration(Decoration decoration) => 
+    private Decoration GetFocusAdjustedDecoration(Decoration decoration) =>
         IsFocused ? decoration : decoration | Decoration.Dim;
 
     private async Task NotifyFocusedValueChangedAsync()


### PR DESCRIPTION
# Overview

The `Options` parameter is explicitly defined as non-nullable `string[]`, so making `EventCallback<string?>` nullable was redundant.

This change aligns the event signature with the data source, resolving ReSharper warnings about method group variance mismatches (e.g., seen in the Gallery example):

<img width="1621" height="301" alt="gallery example" src="https://github.com/user-attachments/assets/19ab2004-a0a3-4845-a47a-78c331561313" />
