### PR TITLE
fix(website):Change lineHeight from 1.2 to 1 in XTermPreview.tsx.

### DIFF
--- a/website/src/components/XTermPreview.tsx
+++ b/website/src/components/XTermPreview.tsx
@@ -106,7 +106,7 @@ export default function XTermPreview({
         const term = new Terminal({
             fontFamily: "'Cascadia Code', 'Fira Code', Consolas, 'Courier New', monospace",
             fontSize: 14,
-            lineHeight: 1.2,
+            lineHeight: 1,
             cursorBlink: true,
             scrollback: 1000,
             cursorInactiveStyle: 'none',


### PR DESCRIPTION
Because of this `lineHeight` value, some components were rendered incorrectly:
Current website:
<img width="1920" height="878" alt="current scrollable" src="https://github.com/user-attachments/assets/a824a0a9-11c5-441b-aa3f-b096f15322de" />
<img width="1920" height="878" alt="current step chart" src="https://github.com/user-attachments/assets/2c7e3228-9201-460e-b4a5-2b76b5e98f96" />


New website:
<img width="1920" height="878" alt="new scrollable" src="https://github.com/user-attachments/assets/e0660508-3e5a-4e32-b436-e84b9507fd38" />
<img width="1920" height="878" alt="new step chart" src="https://github.com/user-attachments/assets/c1ff570b-b709-44c3-827a-89176cb18ec6" />
