### PR TITLE
Fixed missing .NET10 in gallery project

### DIFF
--- a/src/RazorConsole.Gallery/RazorConsole.Gallery.csproj
+++ b/src/RazorConsole.Gallery/RazorConsole.Gallery.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>razorconsole-gallery</ToolCommandName>


### PR DESCRIPTION
Removed TargetFrameworks element from gallery project so Directory.Build.props can flow through. 