### PR TITLE
Add azure-servicebus-console to Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ The following file types are automatically tracked by Git LFS:
 Projects built with RazorConsole:
 
 - [Waves](https://github.com/Skuzzle-UK/Waves) - GitHub Game Off 2025 entry
+- [azure-servicebus-console](https://github.com/zidad/azure-servicebus-console) - Terminal UI browser for Azure Service Bus — browse namespaces, queues, topics and subscriptions, peek/receive messages, and manage entities with delete support
 
 *Want to showcase your project? Submit a PR to add it here!*
 

--- a/src/RazorConsole.Core/Components/Rows.razor
+++ b/src/RazorConsole.Core/Components/Rows.razor
@@ -3,7 +3,8 @@
 @using Microsoft.AspNetCore.Components
 
 <div class="rows"
-    data-expand="@ExpandAttribute">
+    data-expand="@ExpandAttribute"
+    @attributes="AdditionalAttributes">
     @ChildContent
 </div>
 
@@ -31,6 +32,9 @@
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object?>? AdditionalAttributes { get; set; }
 
     private string? ExpandAttribute => Expand ? "true" : "false";
 }

--- a/src/RazorConsole.Core/Components/Scrollable.razor
+++ b/src/RazorConsole.Core/Components/Scrollable.razor
@@ -24,7 +24,9 @@
         </div>
     }
 
-    @ChildContent(new ScrollContext<TItem>(VisibleItems, HandleKeyDown, ScrollOffset, PagesCount))
+    <CascadingValue Name="ScrollableSelection" Value="@_selectionCascade">
+        @ChildContent(new ScrollContext<TItem>(VisibleItems, HandleKeyDown, ScrollOffset, PagesCount))
+    </CascadingValue>
 </scrollable>
 
 
@@ -37,6 +39,11 @@
     /// This component manages pagination and keyboard navigation (arrow keys, page up/down, home/end)
     /// for large lists. It exposes only the currently visible items to the render fragment.
     /// The component is generic and works with any item type specified via the TItem type parameter.
+    ///
+    /// When <see cref="SelectedIndexChanged"/> is bound, the component enters selection mode:
+    /// arrow keys move the selected item and auto-scroll to keep it visible. A
+    /// <see cref="ScrollableSelection"/> is cascaded so child components (e.g. SpectreTBody)
+    /// can highlight the correct row and delegate navigation keys.
     /// </remarks>
 
     /// <summary>
@@ -86,6 +93,27 @@
     public EventCallback<int> ScrollOffsetChanged { get; set; }
 
     /// <summary>
+    /// Currently selected item index (absolute, zero-based into <see cref="Items"/>).
+    /// Only used when <see cref="SelectedIndexChanged"/> is bound.
+    /// </summary>
+    [Parameter]
+    public int SelectedIndex { get; set; }
+
+    /// <summary>
+    /// Raised when the selected item index changes via keyboard navigation.
+    /// When bound, the component enters selection mode: arrow keys move the selection
+    /// and auto-scroll to keep it visible.
+    /// </summary>
+    [Parameter]
+    public EventCallback<int> SelectedIndexChanged { get; set; }
+
+    /// <summary>
+    /// Raised when the user presses Enter on the selected item.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnActivate { get; set; }
+
+    /// <summary>
     /// Scrollbar settings. If provided, the scrollbar is enabled.
     /// </summary>
     [Parameter]
@@ -102,13 +130,107 @@
     [Parameter]
     public bool IsScrollbarEmbedded { get; set; } = true;
 
+    private bool IsSelectionMode => SelectedIndexChanged.HasDelegate;
+
+    private ScrollableSelection? _selectionCascade;
+
     private IReadOnlyList<TItem> VisibleItems
         => Items.Skip(ScrollOffset).Take(PageSize).ToList();
 
     private int PagesCount => PageSize >= Items.Count ? 1 : Items.Count - PageSize + 1;
 
+    protected override void OnParametersSet()
+    {
+        if (IsSelectionMode)
+        {
+            EnsureSelectedVisible();
+            _selectionCascade = new ScrollableSelection(
+                SelectedIndex - ScrollOffset,
+                HandleSelectionKeyDown);
+        }
+        else
+        {
+            _selectionCascade = null;
+        }
+    }
+
+    private void EnsureSelectedVisible()
+    {
+        if (Items.Count == 0) return;
+        int sel = Math.Clamp(SelectedIndex, 0, Items.Count - 1);
+        int page = Math.Max(1, PageSize);
+        if (sel < ScrollOffset)
+            ScrollOffset = sel;
+        else if (sel >= ScrollOffset + page)
+            ScrollOffset = sel - page + 1;
+    }
+
+    private async Task HandleSelectionKeyDown(KeyboardEventArgs e)
+    {
+        int count = Items.Count;
+        if (count == 0) return;
+
+        int page = Math.Max(1, PageSize);
+        int newIndex = SelectedIndex;
+
+        switch (e.Key)
+        {
+            case "ArrowDown":
+            case "DownArrow":
+                newIndex = Math.Min(newIndex + 1, count - 1);
+                break;
+            case "ArrowUp":
+            case "UpArrow":
+                newIndex = Math.Max(newIndex - 1, 0);
+                break;
+            case "PageDown":
+            case " ":
+                newIndex = Math.Min(newIndex + page, count - 1);
+                break;
+            case "PageUp":
+                newIndex = Math.Max(newIndex - page, 0);
+                break;
+            case "Home":
+                newIndex = 0;
+                break;
+            case "End":
+                newIndex = count - 1;
+                break;
+            case "Enter":
+            case "Return":
+                if (OnActivate.HasDelegate)
+                    await OnActivate.InvokeAsync();
+                return;
+            default:
+                return;
+        }
+
+        if (newIndex != SelectedIndex)
+        {
+            SelectedIndex = newIndex;
+            EnsureSelectedVisible();
+
+            if (SelectedIndexChanged.HasDelegate)
+                await SelectedIndexChanged.InvokeAsync(newIndex);
+            if (ScrollOffsetChanged.HasDelegate)
+                await ScrollOffsetChanged.InvokeAsync(ScrollOffset);
+
+            _selectionCascade = new ScrollableSelection(
+                SelectedIndex - ScrollOffset,
+                HandleSelectionKeyDown);
+
+            StateHasChanged();
+        }
+    }
+
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
+        if (IsSelectionMode)
+        {
+            await HandleSelectionKeyDown(e);
+            return;
+        }
+
         int newOffset = ScrollOffset;
         int page = Math.Max(1, PageSize);
         int max = Math.Max(0, Items.Count - page);

--- a/src/RazorConsole.Core/Components/ScrollableSelection.cs
+++ b/src/RazorConsole.Core/Components/ScrollableSelection.cs
@@ -1,0 +1,12 @@
+// Copyright (c) RazorConsole. All rights reserved.
+
+using Microsoft.AspNetCore.Components.Web;
+
+namespace RazorConsole.Components;
+
+/// <summary>
+/// Cascaded from <see cref="Scrollable{TItem}"/> when in selection mode.
+/// Carries the relative selected index (within the visible page) and a key handler
+/// so child components like <see cref="SpectreTBody"/> can delegate navigation.
+/// </summary>
+public sealed record ScrollableSelection(int RelativeSelectedIndex, Func<KeyboardEventArgs, Task> HandleKeyDown);

--- a/src/RazorConsole.Core/Components/SpectreTBody.razor
+++ b/src/RazorConsole.Core/Components/SpectreTBody.razor
@@ -113,6 +113,12 @@ else
     private bool _isFocused;
     private readonly string _focusKey = Guid.NewGuid().ToString("N");
 
+    /// <summary>
+    /// The focus manager key for this tbody, for use with <c>FocusManager.FocusAsync</c>.
+    /// Only meaningful when <see cref="Navigable"/> is true.
+    /// </summary>
+    public string FocusKey => _focusKey;
+
     private string? FocusOrderAttribute => FocusOrder.HasValue
         ? FocusOrder.Value.ToString(CultureInfo.InvariantCulture)
         : null;

--- a/src/RazorConsole.Core/Components/SpectreTBody.razor
+++ b/src/RazorConsole.Core/Components/SpectreTBody.razor
@@ -1,11 +1,32 @@
 @namespace RazorConsole.Components
 
 @using System.Collections.Generic
+@using System.Globalization
 @using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Spectre.Console
 
-<tbody @attributes="AdditionalAttributes">
-    @ChildContent
-</tbody>
+@if (Navigable)
+{
+    <CascadingValue Name="TableNavSelectedIndex" Value="@(_isFocused ? (int?)DisplaySelectedIndex : null)">
+        <tbody @onfocus="OnFocusHandler"
+               @onfocusout="OnFocusOutHandler"
+               @onkeydown="OnKeyDownHandler"
+               data-focusable="true"
+               data-focus-order="@FocusOrderAttribute"
+               @key="_focusKey"
+               data-focus-key="@_focusKey"
+               @attributes="AdditionalAttributes">
+            @ChildContent
+        </tbody>
+    </CascadingValue>
+}
+else
+{
+    <tbody @attributes="AdditionalAttributes">
+        @ChildContent
+    </tbody>
+}
 
 @code {
     /// <summary>
@@ -13,6 +34,8 @@
     /// </summary>
     /// <remarks>
     /// Contains <see cref="SpectreTR"/> rows with <see cref="SpectreTD"/> data cells.
+    /// When <see cref="Navigable"/> is true, the body acts as a single tab stop and
+    /// up/down arrow keys move selection between rows.
     /// </remarks>
 
     /// <summary>
@@ -26,4 +49,160 @@
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IReadOnlyDictionary<string, object?>? AdditionalAttributes { get; set; }
+
+    /// <summary>
+    /// When true, the table body becomes a single focusable element. Up/Down moves
+    /// row selection; Enter activates the selected row.
+    /// </summary>
+    [Parameter]
+    public bool Navigable { get; set; }
+
+    /// <summary>
+    /// Tab order for keyboard navigation. Lower values receive focus first.
+    /// Only used when <see cref="Navigable"/> is true.
+    /// </summary>
+    [Parameter]
+    public int? FocusOrder { get; set; }
+
+    /// <summary>
+    /// Total number of visible rows. Required when <see cref="Navigable"/> is true.
+    /// </summary>
+    [Parameter]
+    public int RowCount { get; set; }
+
+    /// <summary>
+    /// Currently selected row index (zero-based, relative to visible rows).
+    /// </summary>
+    [Parameter]
+    public int SelectedIndex { get; set; }
+
+    /// <summary>
+    /// Raised when the selected row index changes via keyboard navigation.
+    /// </summary>
+    [Parameter]
+    public EventCallback<int> SelectedIndexChanged { get; set; }
+
+    /// <summary>
+    /// Raised when the user presses Enter on the selected row.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnActivate { get; set; }
+
+    /// <summary>
+    /// Callback invoked for key presses that are not handled by the navigation logic
+    /// (e.g. F5, F9, Escape). Use this to forward hotkeys to the page's handler.
+    /// </summary>
+    [Parameter]
+    public Action<KeyboardEventArgs>? OnKeyDown { get; set; }
+
+    /// <summary>
+    /// Cascaded from a parent <see cref="Scrollable{TItem}"/> when it is in selection mode.
+    /// When present, arrow/enter keys are delegated to the Scrollable and the relative
+    /// selected index from the Scrollable is used for row highlighting.
+    /// </summary>
+    [CascadingParameter(Name = "ScrollableSelection")]
+    private ScrollableSelection? ScrollableSelection { get; set; }
+
+    private bool IsScrollableManaged => ScrollableSelection is not null;
+
+    private int DisplaySelectedIndex => IsScrollableManaged
+        ? ScrollableSelection!.RelativeSelectedIndex
+        : _selectedIndex;
+
+    private int _selectedIndex;
+    private bool _isFocused;
+    private readonly string _focusKey = Guid.NewGuid().ToString("N");
+
+    private string? FocusOrderAttribute => FocusOrder.HasValue
+        ? FocusOrder.Value.ToString(CultureInfo.InvariantCulture)
+        : null;
+
+    protected override void OnParametersSet()
+    {
+        if (!Navigable || IsScrollableManaged) return;
+        _selectedIndex = RowCount > 0 && SelectedIndex >= RowCount ? 0 : SelectedIndex;
+    }
+
+    private void OnFocusHandler(FocusEventArgs e)
+    {
+        if (_isFocused) return;
+        _isFocused = true;
+        StateHasChanged();
+    }
+
+    private void OnFocusOutHandler(FocusEventArgs e)
+    {
+        if (!_isFocused) return;
+        _isFocused = false;
+        StateHasChanged();
+    }
+
+    private async Task OnKeyDownHandler(KeyboardEventArgs e)
+    {
+        if (e.CtrlKey || e.AltKey || e.MetaKey)
+        {
+            ForwardKeyDown(e);
+            return;
+        }
+
+        // When inside a selection-aware Scrollable, delegate navigation keys to it.
+        if (IsScrollableManaged)
+        {
+            switch (e.Key)
+            {
+                case "ArrowDown":
+                case "DownArrow":
+                case "ArrowUp":
+                case "UpArrow":
+                case "PageDown":
+                case "PageUp":
+                case "Home":
+                case "End":
+                case " ":
+                case "Enter":
+                case "Return":
+                    await ScrollableSelection!.HandleKeyDown(e);
+                    return;
+            }
+
+            ForwardKeyDown(e);
+            return;
+        }
+
+        if (RowCount > 0)
+        {
+            switch (e.Key)
+            {
+                case "ArrowDown":
+                case "DownArrow":
+                    await SetSelectedAsync((_selectedIndex + 1) % RowCount);
+                    return;
+                case "ArrowUp":
+                case "UpArrow":
+                    await SetSelectedAsync((_selectedIndex - 1 + RowCount) % RowCount);
+                    return;
+                case "Enter":
+                case "Return":
+                    if (OnActivate.HasDelegate)
+                        await OnActivate.InvokeAsync();
+                    return;
+            }
+        }
+
+        ForwardKeyDown(e);
+    }
+
+    private async Task SetSelectedAsync(int index)
+    {
+        _selectedIndex = index;
+        if (SelectedIndexChanged.HasDelegate)
+            await SelectedIndexChanged.InvokeAsync(index);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void ForwardKeyDown(KeyboardEventArgs e)
+    {
+        if (OnKeyDown != null)
+            _ = InvokeAsync(() => OnKeyDown(e));
+    }
 }

--- a/src/RazorConsole.Core/Components/SpectreTR.razor
+++ b/src/RazorConsole.Core/Components/SpectreTR.razor
@@ -2,8 +2,9 @@
 
 @using System.Collections.Generic
 @using Microsoft.AspNetCore.Components
+@using Spectre.Console
 
-<tr @attributes="AdditionalAttributes">
+<tr data-selected-bg="@SelectedBgAttr" @attributes="AdditionalAttributes">
     @ChildContent
 </tr>
 
@@ -13,6 +14,7 @@
     /// </summary>
     /// <remarks>
     /// Use within <see cref="SpectreTHead"/>, <see cref="SpectreTBody"/>, or <see cref="SpectreTFoot"/>. Contains <see cref="SpectreTH"/> or <see cref="SpectreTD"/> cells.
+    /// When inside a navigable <see cref="SpectreTBody"/>, set <see cref="RowIndex"/> to enable row highlighting.
     /// </remarks>
 
     /// <summary>
@@ -26,4 +28,24 @@
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IReadOnlyDictionary<string, object?>? AdditionalAttributes { get; set; }
+
+    /// <summary>
+    /// Zero-based index of this row within the navigable tbody's visible rows.
+    /// Required when inside a navigable <see cref="SpectreTBody"/>.
+    /// </summary>
+    [Parameter]
+    public int RowIndex { get; set; } = -1;
+
+    /// <summary>
+    /// Background color applied to the row when it is selected. Default is <see cref="Color.DodgerBlue1"/>.
+    /// </summary>
+    [Parameter]
+    public Color SelectedBackground { get; set; } = Color.DodgerBlue1;
+
+    [CascadingParameter(Name = "TableNavSelectedIndex")]
+    public int? TableNavSelectedIndex { get; set; }
+
+    private bool IsSelected => RowIndex >= 0 && TableNavSelectedIndex.HasValue && TableNavSelectedIndex.Value == RowIndex;
+
+    private string? SelectedBgAttr => IsSelected ? SelectedBackground.ToHex() : null;
 }

--- a/src/RazorConsole.Core/Components/TextButton.razor
+++ b/src/RazorConsole.Core/Components/TextButton.razor
@@ -24,6 +24,11 @@
     private readonly string _generatedFocusKey = Guid.NewGuid().ToString("N");
 
     /// <summary>
+    /// The focus manager key for this button, for use with FocusManager.FocusAsync.
+    /// </summary>
+    public string FocusKey => _generatedFocusKey;
+
+    /// <summary>
     /// Background color when focused. Default is <see cref="Color.DeepSkyBlue1"/>.
     /// </summary>
     [Parameter]

--- a/src/RazorConsole.Core/Components/TextButton.razor
+++ b/src/RazorConsole.Core/Components/TextButton.razor
@@ -1,8 +1,9 @@
 @using System.Globalization
+@using Microsoft.AspNetCore.Components.Web
 @using Spectre.Console
 @namespace RazorConsole.Components
 
-<div @onfocus="OnFocus" @onfocusout="OnFocusOut" @onclick="OnClick"
+<div @onfocus="OnFocusHandler" @onfocusout="OnFocusOutHandler" @onclick="OnClick" @onkeydown="OnKeyDownHandler"
      data-focusable="true"
      data-focus-order="@FocusOrderAttribute"
      @key="@_generatedFocusKey"
@@ -52,19 +53,50 @@
     [Parameter]
     public int? FocusOrder { get; set; }
 
+    /// <summary>
+    /// Callback invoked when the button receives focus. Uses Action (not EventCallback)
+    /// so tab navigation does not automatically re-render the parent component.
+    /// </summary>
+    [Parameter]
+    public Action<FocusEventArgs>? OnFocus { get; set; }
+
+    /// <summary>
+    /// Callback invoked when the button loses focus.
+    /// </summary>
+    [Parameter]
+    public Action<FocusEventArgs>? OnBlur { get; set; }
+
+    /// <summary>
+    /// Callback invoked when a key is pressed while the button has focus.
+    /// </summary>
+    [Parameter]
+    public Action<KeyboardEventArgs>? OnKeyDown { get; set; }
+
     private string? FocusOrderAttribute => FocusOrder.HasValue
         ? FocusOrder.Value.ToString(CultureInfo.InvariantCulture)
         : null;
 
-    private void OnFocus(FocusEventArgs e)
+    private void OnFocusHandler(FocusEventArgs e)
     {
+        if (_isFocused) return; // FocusManager re-fires after every render — skip to avoid infinite loop
         _isFocused = true;
         StateHasChanged();
+        if (OnFocus != null)
+            _ = InvokeAsync(() => { OnFocus(e); });
     }
 
-    private void OnFocusOut(FocusEventArgs e)
+    private void OnFocusOutHandler(FocusEventArgs e)
     {
+        if (!_isFocused) return;
         _isFocused = false;
         StateHasChanged();
+        if (OnBlur != null)
+            _ = InvokeAsync(() => { OnBlur(e); });
+    }
+
+    private void OnKeyDownHandler(KeyboardEventArgs e)
+    {
+        if (OnKeyDown != null)
+            _ = InvokeAsync(() => { OnKeyDown(e); });
     }
 }

--- a/src/RazorConsole.Core/Renderables/BackgroundRenderable.cs
+++ b/src/RazorConsole.Core/Renderables/BackgroundRenderable.cs
@@ -1,0 +1,44 @@
+// Copyright (c) RazorConsole. All rights reserved.
+
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace RazorConsole.Core.Renderables;
+
+/// <summary>
+/// Applies a background color to all rendered segments of an existing renderable.
+/// </summary>
+public sealed class BackgroundRenderable : IRenderable
+{
+    private readonly IRenderable _inner;
+    private readonly Color _background;
+
+    public BackgroundRenderable(IRenderable inner, Color background)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _background = background;
+    }
+
+    public Measurement Measure(RenderOptions options, int maxWidth)
+        => _inner.Measure(options, maxWidth);
+
+    public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    {
+        foreach (var segment in _inner.Render(options, maxWidth))
+        {
+            if (segment.IsLineBreak)
+            {
+                yield return segment;
+            }
+            else
+            {
+                yield return new Segment(
+                    segment.Text,
+                    new Style(
+                        foreground: segment.Style?.Foreground,
+                        background: _background,
+                        decoration: segment.Style?.Decoration));
+            }
+        }
+    }
+}

--- a/src/RazorConsole.Core/Rendering/Translation/TranslationHelpers.cs
+++ b/src/RazorConsole.Core/Rendering/Translation/TranslationHelpers.cs
@@ -114,13 +114,9 @@ public static class TranslationHelpers
             }
         }
 
-        if (items.Count == 0)
-        {
-            renderable = null;
-            return false;
-        }
-
-        renderable = new BlockInlineRenderable(items);
+        renderable = items.Count == 0
+            ? new Markup(string.Empty)
+            : new BlockInlineRenderable(items);
         return true;
     }
 }

--- a/src/RazorConsole.Core/Rendering/Translation/Translators/HtmlTableElementTranslator.cs
+++ b/src/RazorConsole.Core/Rendering/Translation/Translators/HtmlTableElementTranslator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) RazorConsole. All rights reserved.
 
 using RazorConsole.Core.Abstractions.Rendering;
+using RazorConsole.Core.Renderables;
 using RazorConsole.Core.Rendering.Vdom;
 using RazorConsole.Core.Vdom;
 using Spectre.Console;
@@ -240,6 +241,13 @@ public sealed class HtmlTableElementTranslator : ITranslationMiddleware
     {
         var cells = new List<CellData>();
 
+        var selectedBgStr = VdomSpectreTranslator.GetAttribute(rowNode, "data-selected-bg");
+        Color? rowBackground = null;
+        if (!string.IsNullOrWhiteSpace(selectedBgStr) && Color.TryFromHex(selectedBgStr, out var bgColor))
+        {
+            rowBackground = bgColor;
+        }
+
         foreach (var child in rowNode.Children)
         {
             if (child.Kind != VNodeKind.Element)
@@ -259,6 +267,10 @@ public sealed class HtmlTableElementTranslator : ITranslationMiddleware
                 return false;
             }
 
+            IRenderable cellContent = rowBackground.HasValue
+                ? new BackgroundRenderable(renderable, rowBackground.Value)
+                : renderable;
+
             var alignmentAttribute = VdomSpectreTranslator.GetAttribute(child, "data-align");
             var alignment = ParseAlignment(alignmentAttribute);
 
@@ -267,7 +279,7 @@ public sealed class HtmlTableElementTranslator : ITranslationMiddleware
 
             VdomSpectreTranslator.TryParsePadding(VdomSpectreTranslator.GetAttribute(child, "data-padding"), out var padding);
             VdomSpectreTranslator.TryGetBoolAttribute(child, "data-no-wrap", out var noWrap);
-            cells.Add(new CellData(renderable, alignment, cellWidth, padding, noWrap));
+            cells.Add(new CellData(cellContent, alignment, cellWidth, padding, noWrap));
         }
 
         rowData = new RowData(cells.ToArray());


### PR DESCRIPTION
## Summary

Adds [azure-servicebus-console](https://github.com/zidad/azure-servicebus-console) to the Showcase section.

It's a terminal UI browser for Azure Service Bus built with RazorConsole, featuring:
- Browse namespaces, queues, topics and subscriptions with live message counts
- Peek/receive messages with detail view and JSON body formatting
- Delete queues, topics, subscriptions and individual messages with confirmation dialogs
- Filesystem cache for instant startup with background refresh
- Full keyboard navigation with F-key shortcuts and Blazor routing via `NavigationManager`